### PR TITLE
Add per-processor requirements and sample code

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,23 @@ A collection of Python scripts to interact with Aquarius DMS via the Aquarius We
     pip install -r requirements.txt
     ```
 
+    Each processor under `service/` also provides its own minimal requirements
+    file if you only need a subset of the features.  For example:
+
+    ```bash
+    pip install -r service/requirements_pdf.txt      # PDF importer only
+    pip install -r service/requirements_csv.txt      # CSV importer only
+    pip install -r service/requirements_ocr.txt      # OCR processing only
+    pip install -r service/requirements_docid.txt    # Barcode DocID importer
+    pip install -r service/requirements_fulltext.txt # Full text indexing
+    ```
+
+    On Windows machines install the [Tesseract OCR engine](https://github.com/UB-Mannheim/tesseract/wiki)
+    if you plan to use OCR. Some packages such as `opencv-python` may require the
+    Microsoft Visual C++ Redistributable. After installing the Python packages
+    you may need to run `pywin32_postinstall.py -install` from the `Scripts`
+    folder of your virtual environment.
+
 4. **Environment Variables**:
 
     Copy `.env.example` to `.env` and fill in the required variables:

--- a/service/aquarius_unified_service.py
+++ b/service/aquarius_unified_service.py
@@ -3,8 +3,15 @@ from service.service_base import SMWinservice
 from service.generic_watcher import GenericWatcher
 from service.process_ocr import OCRProcessor
 from service.process_fulltext import TextFileHandler
+from service.process_import_pdf import ImportProcessorPDF
+from service.process_import_csv import ImportProcessorCSV
+from service.process_import_docid import ImportProcessorBarcodeDocID
+
 import service.config_ocr as config_ocr
 import service.config_fulltext_index as config_fulltext_index
+import service.config_import_pdf as config_import_pdf
+import service.config_import_csv as config_import_csv
+import service.config_import as config_import
 
 #******************* LOAD THE CONFIGURATION FILE ********************************************
 from dotenv import load_dotenv
@@ -20,23 +27,57 @@ class AquariusFileWatcherService(SMWinservice):
         
         self.isrunning = True
         
-        processors=[]
+        processors = []
 
+        # --- Sample processor definitions ---------------------------------
+
+        # Uncomment any of the following blocks to enable a processor.
+
+        # PDF Import Processor
+        # processors.append(ImportProcessorPDF({
+        #     "folder_to_watch": config_import_pdf.folder_to_watch,
+        #     "process_existing_files": config_import_pdf.process_existing_files,
+        #     "field_mappings": config_import_pdf.field_mappings,
+        #     "document_type_id": config_import_pdf.document_type_id,
+        #     "server": config_import_pdf.aquarius_api_url,
+        #     "username": config_import_pdf.username,
+        #     "password": config_import_pdf.password,
+        # }))
+
+        # CSV Import Processor
+        # processors.append(ImportProcessorCSV({
+        #     "folder_to_watch": config_import_csv.folder_to_watch,
+        #     "process_existing_files": config_import_csv.process_existing_files,
+        #     "document_type_id": config_import_csv.document_type_id,
+        #     "field_mappings": config_import_csv.field_mappings,
+        #     "pdf_index": config_import_csv.pdf_index,
+        #     "server": config_import_csv.aquarius_api_url,
+        #     "username": config_import_csv.username,
+        #     "password": config_import_csv.password,
+        # }))
+
+        # Barcode DocID Import Processor
+        # for folder, process_existing_files in config_import.folders_to_watch.items():
+        #     processors.append(ImportProcessorBarcodeDocID({
+        #         "folder_to_watch": folder,
+        #         "process_existing_files": process_existing_files,
+        #         "server": config_import.aquarius_api_url,
+        #         "username": config_import.username,
+        #         "password": config_import.password,
+        #     }))
+
+        # OCR Processor
         for folder, process_existing_files in config_ocr.folders_to_watch.items():
-        # Create a processor instance and inject the folder and flag into the handler.
             processors.append(OCRProcessor({
                 "folder_to_watch": folder,
                 "process_existing_files": process_existing_files
             }))
 
+        # Full Text Index Processor
         if config_fulltext_index.folder_solr_mapping:
             for folder_to_watch, mapping in config_fulltext_index.folder_solr_mapping.items():
-
-                print(f"Watching folder: {folder_to_watch}")
-                                               
                 solrUrl = mapping["solrUrl"]
                 path_replacement_pairs = mapping["path_replacement_pairs"]
-                
                 processors.append(TextFileHandler({
                     "folder_to_watch": folder_to_watch,
                     "solrUrl": solrUrl,

--- a/service/readme.txt
+++ b/service/readme.txt
@@ -1,6 +1,24 @@
 
-OCR Requires Tesseract ocr installed on the machine and added to the path.
-Full text processing requires solr server.
+OCR Requires the Tesseract OCR engine installed on the machine and added to the
+PATH. On Windows you can download it from https://github.com/UB-Mannheim/tesse
+ract/wiki.
+Full text processing requires a Solr server.
+
+Windows installations may also require the Microsoft Visual C++ Redistributable
+for some packages (e.g., opencv-python). After installing dependencies, run
+`pywin32_postinstall.py -install` from the Python Scripts directory if prompted.
+
+Each processor has its own requirements file. Install only what you need using
+`pip install -r <file>`:
+
+```
+requirements_base.txt      # Generic watcher/service support
+requirements_pdf.txt       # PDF import processor
+requirements_csv.txt       # CSV import processor
+requirements_docid.txt     # Barcode DocID processor
+requirements_ocr.txt       # OCR processor
+requirements_fulltext.txt  # Full text indexing
+```
 
 
 

--- a/service/requirements_base.txt
+++ b/service/requirements_base.txt
@@ -1,0 +1,3 @@
+watchdog==3.0.0
+pywin32==306; platform_system=="Windows"
+python-dotenv==1.0.0

--- a/service/requirements_csv.txt
+++ b/service/requirements_csv.txt
@@ -1,0 +1,2 @@
+PyPDF2==3.0.1
+python-dotenv==1.0.0

--- a/service/requirements_docid.txt
+++ b/service/requirements_docid.txt
@@ -1,0 +1,5 @@
+Pillow==9.0.0
+pyzbar==0.1.9
+opencv-python==4.6.0.66; platform_system=="Windows"
+numpy==1.21.3
+python-dotenv==1.0.0

--- a/service/requirements_fulltext.txt
+++ b/service/requirements_fulltext.txt
@@ -1,0 +1,2 @@
+pysolr==3.9.0
+python-dotenv==1.0.0

--- a/service/requirements_ocr.txt
+++ b/service/requirements_ocr.txt
@@ -1,0 +1,4 @@
+# Requires the Tesseract OCR engine to be installed separately on Windows
+pytesseract==0.3.10
+Pillow==9.0.0
+python-dotenv==1.0.0

--- a/service/requirements_pdf.txt
+++ b/service/requirements_pdf.txt
@@ -1,0 +1,2 @@
+PyPDF2==3.0.1
+python-dotenv==1.0.0


### PR DESCRIPTION
## Summary
- add minimal requirements files for each processor
- update install instructions to mention new requirements
- document service requirement files
- add commented sample code for PDF, CSV and DocID processors in `aquarius_unified_service.py`
- mention Windows-specific dependencies

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68431f42de98833384aa44b2e587a169